### PR TITLE
Clean commits

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -152,7 +152,10 @@ const Dashboard = () => {
   const handleToggle = (protection) => {
     const isSelected = selectedProtections.includes(protection);
     const includedCount = config.included;
-    const maxProtections = tier === "Alpha" ? Infinity : tierConfig[tier].max;
+    const maxProtections =
+      tier === "Alpha" || tier === "Enterprise"
+        ? Infinity
+        : tierConfig[tier].max;
     const currentCount = selectedProtections.length;
     const isNotCurrentlySelected = !isSelected;
 
@@ -172,7 +175,8 @@ const Dashboard = () => {
     if (isInSwapMode && removedProtection && isNotCurrentlySelected) {
       // This is a swap operation
       const isFreeSwap = swapCount === 0 && tier === "Pup SR.";
-      const isUnlimitedSwap = tier === "Guardian" || tier === "Alpha";
+      const isUnlimitedSwap =
+        tier === "Guardian" || tier === "Alpha" || tier === "Enterprise";
 
       if (isFreeSwap || isUnlimitedSwap) {
         setOriginalProtections([...selectedProtections]);
@@ -254,7 +258,8 @@ const Dashboard = () => {
         // If we just removed a protection (creating swap opportunity), treat as swap
         if (removedProtection) {
           const isFreeSwap = swapCount === 0 && tier === "Pup SR.";
-          const isUnlimitedSwap = tier === "Guardian" || tier === "Alpha";
+          const isUnlimitedSwap =
+            tier === "Guardian" || tier === "Alpha" || tier === "Enterprise";
 
           if (isFreeSwap || isUnlimitedSwap) {
             setOriginalProtections([...selectedProtections]);
@@ -538,6 +543,8 @@ const Dashboard = () => {
           {tier === "Guardian" &&
             "Up to 3 add-ons ($10 each), unlimited swaps."}
           {tier === "Alpha" && "Unlimited add-ons, unlimited swaps."}
+          {tier === "Enterprise" &&
+            "Unlimited add-ons, unlimited swaps, Contact Sales."}
         </span>
       </div>
 
@@ -1017,6 +1024,13 @@ const Dashboard = () => {
                   </div>
                 )}
                 {tier === "Alpha" && (
+                  <div className="mt-3 text-center">
+                    <span className="text-sm text-green-300 font-semibold">
+                      Unlimited swaps included
+                    </span>
+                  </div>
+                )}
+                {tier === "Enterprise" && (
                   <div className="mt-3 text-center">
                     <span className="text-sm text-green-300 font-semibold">
                       Unlimited swaps included

--- a/src/components/FeatureMatrix.js
+++ b/src/components/FeatureMatrix.js
@@ -60,25 +60,12 @@ const tierConfig = {
   },
 };
 
-const tiers = ["Pup JR.", "Pup SR.", "Guardian", "Alpha"];
+const tiers = ["Pup JR.", "Pup SR.", "Guardian", "Alpha", "Enterprise"];
 
 const FeatureMatrix = () => {
   const { tier, allProtections } = useTier();
 
-  // Add CSS to remove only the vertical border between Alpha and Contact Sales
-  React.useEffect(() => {
-    const style = document.createElement("style");
-    style.textContent = `
-      .feature-matrix-table th:nth-child(5) {
-        border-right: none !important;
-      }
-      .feature-matrix-table th:nth-child(6) {
-        border-left: none !important;
-      }
-    `;
-    document.head.appendChild(style);
-    return () => document.head.removeChild(style);
-  }, []);
+  // No special CSS needed since Enterprise is now part of the main table
 
   // For each tier, get the set of included protections (first N from allProtections)
   const tierProtections = {};
@@ -96,6 +83,8 @@ const FeatureMatrix = () => {
     if (tierOption === "Guardian")
       return `Up to 3 add-ons ($10 each), unlimited swaps`;
     if (tierOption === "Alpha") return `Unlimited add-ons, unlimited swaps`;
+    if (tierOption === "Enterprise")
+      return `Unlimited add-ons, unlimited swaps, Contact Sales`;
     return "-";
   };
 
@@ -124,19 +113,18 @@ const FeatureMatrix = () => {
                     <span style={{ whiteSpace: "nowrap" }}>Pup JR.</span>
                   ) : tierOption === "Pup SR." ? (
                     <span style={{ whiteSpace: "nowrap" }}>Pup SR.</span>
+                  ) : tierOption === "Enterprise" ? (
+                    <div>
+                      <div style={{ whiteSpace: "nowrap" }}>Enterprise</div>
+                      <div className="text-xs text-green-400">
+                        Contact Sales
+                      </div>
+                    </div>
                   ) : (
                     tierOption
                   )}
                 </th>
               ))}
-              <th className="px-4 py-2 font-semibold bg-gray-800 text-green-400 rounded-tr-lg">
-                <a
-                  href="/contact-sales"
-                  className="inline-block px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-lg font-bold transition"
-                >
-                  Contact Sales
-                </a>
-              </th>
             </tr>
           </thead>
           <tbody>
@@ -150,7 +138,7 @@ const FeatureMatrix = () => {
                   <td
                     key={tierOption}
                     className={`px-4 py-2 text-center ${
-                      tierOption === "Alpha" ? "rounded-r-lg" : ""
+                      tierOption === "Enterprise" ? "rounded-r-lg" : ""
                     }`}
                   >
                     {tierProtections[tierOption].includes(protection) ? (

--- a/src/components/FeatureMatrix.js
+++ b/src/components/FeatureMatrix.js
@@ -141,7 +141,9 @@ const FeatureMatrix = () => {
                       tierOption === "Enterprise" ? "rounded-r-lg" : ""
                     }`}
                   >
-                    {tierProtections[tierOption].includes(protection) ? (
+                    {tierOption === "Enterprise" ? (
+                      <span className="text-gray-600">-</span>
+                    ) : tierProtections[tierOption].includes(protection) ? (
                       <span className="text-green-400 text-lg">&#10003;</span>
                     ) : (
                       <span className="text-gray-600">-</span>

--- a/src/components/TierContext.js
+++ b/src/components/TierContext.js
@@ -50,12 +50,18 @@ const tierConfig = {
     unlimitedSwap: true,
     unlimitedProtection: true,
   },
-  // Enterprise: hidden
+  // Enterprise: Contact Sales
   Enterprise: {
     price: 2500,
     included: 15,
-    max: 15,
-    extra: 0,
+    max: Infinity, // Unlimited protections
+    extra: Infinity,
+    addons: Infinity,
+    addonsPrice: 0,
+    swap: Infinity,
+    swapPrice: 0,
+    unlimitedSwap: true,
+    unlimitedProtection: true,
     contact: true,
   },
 };


### PR DESCRIPTION
📊 Feature Matrix Update:
Enterprise column now shows dashes (-) for all protections
Other tiers still show checkmarks (✅) for included protections
Clear distinction between automatic inclusion vs. contact sales

🎯 Visual Logic:
Pup JR., Pup SR., Guardian, Alpha: Show checkmarks for included protections
Enterprise: Shows dashes for all protections (indicating "Contact Sales" discussion)

💼 User Experience:
Clear messaging - Dashes indicate Enterprise requires sales discussion
Professional presentation - Enterprise appears as a custom solution
No confusion - Users understand Enterprise is not automatic inclusion
